### PR TITLE
Added test and allowed setting seed for biMAP

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: CAbiNet
 Type: Package
 Title: Biclustering and visualization of scRNAseq data
-Version: 0.99.0
+Version: 0.99.1
 Authors@R:
   c(person(given = "Clemens",
            family = "Kohl",

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -17,3 +17,7 @@ calc_overlap <- function(cc_adj, cg_adj, threshold) {
     invisible(.Call('_CAbiNet_calc_overlap', PACKAGE = 'CAbiNet', cc_adj, cg_adj, threshold))
 }
 
+calc_overlap_deprecated <- function(cc_adj, cg_adj) {
+    .Call('_CAbiNet_calc_overlap_deprecated', PACKAGE = 'CAbiNet', cc_adj, cg_adj)
+}
+

--- a/R/biMAP.R
+++ b/R/biMAP.R
@@ -53,7 +53,8 @@ run_biMAP <- function(obj,
 
     umap_coords <- python_umap(dm = SNNdist,
                                 metric = "precomputed",
-                                n_neighbors = as.integer(k))
+                                n_neighbors = as.integer(k),
+                               seed = rand_seed)
 
     umap_coords <- as.data.frame(umap_coords)
     rownames(umap_coords) <- colnames(SNNdist)

--- a/inst/python/umap.py
+++ b/inst/python/umap.py
@@ -1,11 +1,11 @@
 import umap.umap_ as umap
 
 def python_umap(dm, n_neighbors, metric, seed=2358):
-                  
+  
   reducer = umap.UMAP(
         n_neighbors=n_neighbors,
         metric=metric,
-        random_state = seed
+        random_state = int(seed)
         )
         
   embedding = reducer.fit_transform(dm)

--- a/inst/python/umap.py
+++ b/inst/python/umap.py
@@ -1,10 +1,11 @@
 import umap.umap_ as umap
 
-def python_umap(dm, n_neighbors, metric):
+def python_umap(dm, n_neighbors, metric, seed=2358):
                   
   reducer = umap.UMAP(
         n_neighbors=n_neighbors,
-        metric=metric
+        metric=metric,
+        random_state = seed
         )
         
   embedding = reducer.fit_transform(dm)

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -36,10 +36,23 @@ BEGIN_RCPP
     return R_NilValue;
 END_RCPP
 }
+// calc_overlap_deprecated
+Eigen::SparseMatrix<double> calc_overlap_deprecated(Eigen::SparseMatrix<int> cc_adj, Eigen::SparseMatrix<int> cg_adj);
+RcppExport SEXP _CAbiNet_calc_overlap_deprecated(SEXP cc_adjSEXP, SEXP cg_adjSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Eigen::SparseMatrix<int> >::type cc_adj(cc_adjSEXP);
+    Rcpp::traits::input_parameter< Eigen::SparseMatrix<int> >::type cg_adj(cg_adjSEXP);
+    rcpp_result_gen = Rcpp::wrap(calc_overlap_deprecated(cc_adj, cg_adj));
+    return rcpp_result_gen;
+END_RCPP
+}
 
 static const R_CallMethodDef CallEntries[] = {
     {"_CAbiNet_ComputeSNNasym", (DL_FUNC) &_CAbiNet_ComputeSNNasym, 3},
     {"_CAbiNet_calc_overlap", (DL_FUNC) &_CAbiNet_calc_overlap, 3},
+    {"_CAbiNet_calc_overlap_deprecated", (DL_FUNC) &_CAbiNet_calc_overlap_deprecated, 2},
     {NULL, NULL, 0}
 };
 

--- a/src/testing_funs.cpp
+++ b/src/testing_funs.cpp
@@ -1,0 +1,49 @@
+#include <RcppEigen.h>
+#include <vector> //std::vector
+#include <string>
+// #include <math> //for NAN
+#include <iostream>
+using namespace Rcpp;
+
+// [[Rcpp::export]]
+Eigen::SparseMatrix<double> calc_overlap_deprecated(Eigen::SparseMatrix<int> cc_adj,
+                                                    Eigen::SparseMatrix<int> cg_adj) {
+    
+    // initialize vector to store triplets
+    typedef Eigen::Triplet<double> Trip;
+    std::vector<Trip> trp;
+    Eigen::SparseMatrix<int> overlap_mat_all = cc_adj * cg_adj;
+    Eigen::SparseMatrix<int> cc_tadj = cc_adj.transpose();
+    
+    // calcualte the rowSums of matrix cc_adj which is also the number of neighbourhoods of each cell
+    std::vector<double> cell_nn_nums;
+    for (int i=0; i < cc_tadj.outerSize(); i++){
+        int k = 0;
+        
+        for (Eigen::SparseMatrix<int>::InnerIterator it(cc_tadj, i); it; ++it){  // Iterate over rows
+            k += 1;
+        }
+        
+        cell_nn_nums.push_back(k);
+    }
+    
+    // loop over genes (its faster in column major matrix)
+    for (int i=0; i < cg_adj.outerSize(); i++){
+        
+        // only preserve the edges which are shown in cg_adj matrix
+        for (Eigen::SparseMatrix<int>::InnerIterator it(cg_adj, i); it; ++it){  // Iterate over rows
+            
+            double value = overlap_mat_all.coeffRef(it.row(), i)/cell_nn_nums[it.row()];
+            
+            trp.push_back(Trip(it.row(),
+                               i, 
+                               value));
+        }
+    }
+    
+    // build Matrix from triplets
+    Eigen::SparseMatrix<double> overlap(cg_adj.rows(), cg_adj.cols());
+    overlap.setFromTriplets(trp.begin(), trp.end());
+    
+    return overlap;
+}

--- a/src/testing_funs.cpp
+++ b/src/testing_funs.cpp
@@ -47,3 +47,5 @@ Eigen::SparseMatrix<double> calc_overlap_deprecated(Eigen::SparseMatrix<int> cc_
     
     return overlap;
 }
+
+

--- a/tests/testthat/testing_helpers.R
+++ b/tests/testthat/testing_helpers.R
@@ -178,8 +178,8 @@ create_bigraph_manual <- function(cell_dists,
     
     if(isTRUE(select_genes) & isTRUE(prune_overlap)){
         
-        overlap_mat <- calc_overlap( cc_adj = ccg_nn,
-                                     cg_adj = cgg_nn)
+        overlap_mat <- calc_overlap_deprecated( cc_adj = ccg_nn,
+                                               cg_adj = cgg_nn)
         
         # For the case overlap = 1, all the genes are supposed to removed such that
         # the algorithm allows for clustering for cells without genes.


### PR DESCRIPTION
I could not replicate my biMAP plots despite setting a seed. Turns out we did not hand the seed over to the python function. the `int()` is needed because reticulate makes a float out of integers.

Otherwise I just added a test that checks  if we get the same results compared to the old calc_overlap function.