### PR TITLE
pytorch -> torch

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -89,7 +89,7 @@ Config/reticulate:
     packages = list(
       list(package = "numpy"),
       list(package = "scipy"),
-      list(package = "pytorch"),
+      list(package = "torch"),
       list(package = "scikit-learn"),
       list(package = "umap-learn")
     )


### PR DESCRIPTION
Apparently pytorch is called `pytorch` when installing it with conda and `torch`  when installing it via pip. Reticulate seems to take the dependencies listed in the DESCRIPTION and installs them with pip into the environment.

Interestingly I ran into when running cacomp (from the APL package) in the vignette, but changing it in the CAbiNet DESCRIPTION fixed it for me. Maybe could you see if you can reproduce the problem by running the code in the vignette and if running the updated code here solves it for you too?